### PR TITLE
sh: 1: Syntax error: Bad fd number

### DIFF
--- a/lib/ffi-compiler/compile_task.rb
+++ b/lib/ffi-compiler/compile_task.rb
@@ -197,7 +197,7 @@ module FFI
             f << src
           end
           begin
-            return system "#{cc} #{opts.join(' ')} -o #{File.join(dir, 'ffi-test')} #{path} >/dev/null 2>&1"
+            return system "#{cc} #{opts.join(' ')} -o #{File.join(dir, 'ffi-test')} #{path} > /dev/null 2>&1"
           rescue
             return false
           end


### PR DESCRIPTION
```
>& /dev/null
```

This will run corrent in csh or bash (bash is compatible in this case with csh). But Ubuntu links /bin/sh to dash! And we have such error:

```
sh: 1: Syntax error: Bad fd number
```
