### PR TITLE
On windows, the start path for library loading is set to '.'

### DIFF
--- a/lib/ffi-compiler/loader.rb
+++ b/lib/ffi-compiler/loader.rb
@@ -8,7 +8,7 @@ module FFI
       def self.find(name, start_path = nil)
         library = Platform.system.map_library_name(name)
         root = false
-        Pathname.new(start_path || File.dirname(caller[0].split(/:/)[0])).ascend do |path|
+        Pathname.new(start_path || caller_path(caller[0])).ascend do |path|
           Dir.glob("#{path}/**/{#{FFI::Platform::ARCH}-#{FFI::Platform::OS}/#{library},#{library}}") do |f|
             return f
           end
@@ -19,6 +19,17 @@ module FFI
           root = File.basename(path) == 'lib'
         end
         raise LoadError.new("cannot find '#{name}' library")
+      end
+
+      def self.caller_path(line = caller[0])
+        if FFI::Platform::OS == 'windows'
+          drive = line[0..1]
+          path =  line[2..-1].split(/:/)[0]
+          full_path = drive + path
+        else
+          full_path = line.split(/:/)[0]
+        end
+        File.dirname full_path
       end
     end
   end


### PR DESCRIPTION
The path in caller[0] includes the drive letter followed by :, which is the separator
we use to split the path.  i.e. c:/foo/bar/file.rb.

I added a small method with logic specific to Windows
