### PR TITLE
Few improvements

### DIFF
--- a/lib/ffi-compiler/compile_task.rb
+++ b/lib/ffi-compiler/compile_task.rb
@@ -143,7 +143,7 @@ module FFI
         @exports.each do |e|
           desc "Export #{e[:rb_file]}"
           file e[:header] => [ e[:rb_file] ] do |t|
-            ruby "-I#{File.join(File.dirname(__FILE__), 'fake_ffi')} #{File.join(File.dirname(__FILE__), 'exporter.rb')} #{t.prerequisites[0]} #{t.name}"
+            ruby "-I#{File.join(File.dirname(__FILE__), 'fake_ffi')} -I#{File.dirname(t.prerequisites[0])} #{File.join(File.dirname(__FILE__), 'exporter.rb')} #{t.prerequisites[0]} #{t.name}"
           end
 
           obj_files.each { |o| file o  => [ e[:header] ] }


### PR DESCRIPTION
`add_include_path` and `add_define` methods so that when compiling can specify those in Rakefile

Add load path where `rb_file` is located so that `require` works correctly for export.

Remove `/dev/null` as it wont work in Windows, it will complain that file not found. In Windows it's `> nul` but that won't work for Linux, so we just save output to file and because that directory is tmp it will be deleted after anyway.
