### PR TITLE
Remove `has_rdoc`

### DIFF
--- a/example/example.gemspec
+++ b/example/example.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.summary = 'Ruby FFI example'
   s.description = 'Ruby FFI example'
   s.files = %w(Rakefile example.gemspec) + Dir.glob("{lib,spec,ext}/**/*")
-  s.has_rdoc = false
   s.license = 'unknown'
   s.required_ruby_version = '>= 1.9.3'
   s.extensions << 'ext/Rakefile'

--- a/ffi-compiler.gemspec
+++ b/ffi-compiler.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.summary = 'Ruby FFI Rakefile generator'
   s.description = 'Ruby FFI library'
   s.files = %w(ffi-compiler.gemspec Gemfile Rakefile README.md LICENSE) + Dir.glob("{lib,spec}/**/*")
-  s.has_rdoc = false
   s.license = 'Apache 2.0'
   s.required_ruby_version = '>= 1.9'
   s.add_dependency 'rake'


### PR DESCRIPTION
It's deprecated and gives this warning when running bundler.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /mnt/RAID/Projekti/Git/ffi-compiler/ffi-compiler.gemspec:12.
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /mnt/RAID/Projekti/Git/ffi-compiler/example/example.gemspec:10.
```
