### PR TITLE
Fix load library order

### DIFF
--- a/lib/ffi-compiler/loader.rb
+++ b/lib/ffi-compiler/loader.rb
@@ -9,7 +9,11 @@ module FFI
         library = Platform.system.map_library_name(name)
         root = false
         Pathname.new(start_path || caller_path(caller[0])).ascend do |path|
-          Dir.glob("#{path}/**/{#{FFI::Platform::ARCH}-#{FFI::Platform::OS}/#{library},#{library}}") do |f|
+          Dir.glob("#{path}/**/#{FFI::Platform::ARCH}-#{FFI::Platform::OS}/#{library}") do |f|
+            return f
+          end
+
+          Dir.glob("#{path}/**/#{library}") do |f|
             return f
           end
 


### PR DESCRIPTION
The following method takes any file matching any pattern provided with no intentional order.

```ruby
 Dir.glob("#{path}/**/{#{FFI::Platform::ARCH}-#{FFI::Platform::OS}/#{library},#{library}}")
```

In particular on the `x86_64` Windows it chooses `i386-windows/libmspack.dll` instead of `x86_64-windows/libmspack.dll`.

This PR fixes the issue. What do you think?

Follows https://github.com/davispuh/ffi-compiler/pull/2