### PR TITLE
Respect user's environment FLAGS

### DIFF
--- a/lib/ffi-compiler/compile_task.rb
+++ b/lib/ffi-compiler/compile_task.rb
@@ -26,9 +26,9 @@ module FFI
         @libraries = []
         @headers = []
         @functions = []
-        @cflags = DEFAULT_CFLAGS.dup
-        @cxxflags = DEFAULT_CFLAGS.dup
-        @ldflags = DEFAULT_LDFLAGS.dup
+        @cflags = ENV['CFLAGS']&.split || DEFAULT_CFLAGS.dup
+        @cxxflags = ENV['CXXFLAGS']&.split || DEFAULT_CFLAGS.dup
+        @ldflags = ENV['LDFLAGS']&.split || DEFAULT_LDFLAGS.dup
         @libs = []
         @platform = Platform.system
         @exports = []


### PR DESCRIPTION
Hi, currently ffi-compiler does not respect the CFLAGS set by a user or build system and instead builds its extensions with its own hardcoded set of flags.  This should have it properly respect the flags that a user requests to build with.