### PR TITLE
Make MultiFileTask ignore the scope like FileTask

### DIFF
--- a/lib/ffi-compiler/multi_file_task.rb
+++ b/lib/ffi-compiler/multi_file_task.rb
@@ -36,6 +36,14 @@ module FFI
                     end
                 end
             end
+
+            class << self
+                # Apply the scope to the task name according to the rules for this kind
+                # of task.  File based tasks ignore the scope when creating the name.
+                def scope_name(scope, task_name)
+                  Rake.from_pathname(task_name)
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes #26.

The issue is that `Rake::FileTask` ignores the scope when being created under a rake namespace: https://github.com/ruby/rake/blob/15e936c87aca9789b6f7a2a0c91566f972720ece/lib/rake/file_task.rb#L50-L56

However, `FFI::Compiler::MultiFileTask` honors with the namespace, thus the task would be created with a different fully qualified name, and breaks existing code.